### PR TITLE
Upgrade to elm-review 2.x syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,26 @@ A rule for elm-review that discourages keeping very long one-line `import`
 statements.
 
 Some Elm tools will change multi-line import statements back to a single line
-when modifying the `exposing ()` section. 
-
-
+when modifying the `exposing ()` section.
 
 ## Usage
 
 After adding [`elm-review`][elm-review] to your project, import this rule from
 your `ReviewConfig.elm` file and add it to the config. E.g.:
 
-    import NoLongImportLines
-    import Review.Rule exposing (Rule)
+```elm
+import NoLongImportLines
+import Review.Rule exposing (Rule)
 
-    config : List Rule
-    config =
-        [ NoLongImportLines.rule ]
+config : List Rule
+config =
+    [ NoLongImportLines.rule ]
+```
 
 [elm-review]: https://package.elm-lang.org/packages/jfmengels/elm-review/latest/
-
 
 ## Roadmap
 
 - [ ] Save users from users having to manually break up the line, by adding a [`fix`][fix]
 
-[fix]: https://package.elm-lang.org/packages/jfmengels/elm-review/latest/Review-Fix 
+[fix]: https://package.elm-lang.org/packages/jfmengels/elm-review/latest/Review-Fix

--- a/elm.json
+++ b/elm.json
@@ -7,16 +7,11 @@
     "exposed-modules": [
         "NoLongImportLines"
     ],
-    "source-directories": [
-        "src"
-    ],
-    "elm-version": "0.19.1 <= v < 0.20.0",
+    "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "elm/browser": "1.0.2 <= v < 2.0.0",
         "elm/core": "1.0.5 <= v < 2.0.0",
-        "elm/html": "1.0.0 <= v < 2.0.0",
-        "jfmengels/elm-review": "1.0.0 <= v < 3.0.0",
-        "stil4m/elm-syntax": "7.1.1 <= v < 8.0.0"
+        "jfmengels/elm-review": "2.2.0 <= v < 3.0.0",
+        "stil4m/elm-syntax": "7.1.3 <= v < 8.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.2.2 <= v < 2.0.0"

--- a/src/NoLongImportLines.elm
+++ b/src/NoLongImportLines.elm
@@ -38,14 +38,21 @@ import Review.Rule as Rule exposing (Error, Rule, error)
 
 {-| A rule for elm-review that discourages the use of very long `import`
 statements, which are prone to merge conflicts.
+
+    import NoLongImportLines
+    import Review.Rule exposing (Rule)
+
+    config : List Rule
+    config =
+        [ NoLongImportLines.rule
+        ]
+
 -}
 rule : Rule
 rule =
-    -- Define the rule with the same name as the module it is defined in
-    Rule.newSchema "NoLongImportLines"
-        -- Make it look at declarations
+    Rule.newModuleRuleSchema "NoLongImportLines" ()
         |> Rule.withSimpleImportVisitor importVisitor
-        |> Rule.fromSchema
+        |> Rule.fromModuleRuleSchema
 
 
 details =
@@ -59,7 +66,7 @@ details =
     }
 
 
-importVisitor : Node Import -> List Error
+importVisitor : Node Import -> List (Error {})
 importVisitor node =
     let
         range : Range


### PR DESCRIPTION
Simple syntax changes to allow this to work with elm-review 2.x. Also removed unused dependencies on `elm/browser` and `elm/html` and added elm formatting to the README.